### PR TITLE
fix: dev da

### DIFF
--- a/internal/components_phylax.go
+++ b/internal/components_phylax.go
@@ -26,9 +26,6 @@ func (a *AssertionDA) Run(service *Service, ctx *ExContext) {
 }
 
 func (a *AssertionDA) Name() string {
-	if a.DevMode {
-		return "assertion-da-dev"
-	}
 	return "assertion-da"
 }
 

--- a/internal/recipe_phylax.go
+++ b/internal/recipe_phylax.go
@@ -77,6 +77,7 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 
 	externalDaRef := o.externalDA
 	if o.externalDA == "" || o.externalDA == "dev" {
+
 		svcManager.AddService("assertion-da", &AssertionDA{
 			DevMode: o.externalDA == "dev",
 			// cast keccak "credible-layer-sandbox-assertion-da"


### PR DESCRIPTION
Fixes dev da configuration. 
We want to avoid parameterizing the service name because it makes matching when adding the service, and marking a service as a dependency, more complex.