### PR TITLE
feat: add custom image passing to playground

### DIFF
--- a/main.go
+++ b/main.go
@@ -229,7 +229,10 @@ func runIt(recipe playground.Recipe) error {
 		return err
 	}
 
-	svcManager := recipe.Apply(&playground.ExContext{LogLevel: logLevel, AlloyEnabled: withGrafanaAlloy, CaddyEnabled: len(withCaddy) > 0}, artifacts)
+	svcManager, err := recipe.Apply(&playground.ExContext{LogLevel: logLevel, AlloyEnabled: withGrafanaAlloy, CaddyEnabled: len(withCaddy) > 0}, artifacts)
+	if err != nil {
+		return fmt.Errorf("failed to apply recipe: %w", err)
+	}
 
 	if withGrafanaAlloy {
 		if err := playground.CreateGrafanaAlloyServices(svcManager, artifacts.Out); err != nil {

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -72,11 +72,13 @@ type OpTalos struct {
 	AssertionDA    string
 	AssexGasLimit  uint64
 	OracleContract string
+	ImageName      string
+	ImageTag       string
 }
 
 func (o *OpTalos) Run(service *Service, ctx *ExContext) {
-	service.WithImage("ghcr.io/phylaxsystems/op-talos/op-rbuilder").
-		WithTag("master").
+	service.WithImage(o.ImageName).
+		WithTag(o.ImageTag).
 		WithArgs(
 			"node",
 			"--authrpc.port", `{{Port "authrpc" 8551}}`,

--- a/playground/manifest.go
+++ b/playground/manifest.go
@@ -19,7 +19,7 @@ type Recipe interface {
 	Description() string
 	Flags() *flag.FlagSet
 	Artifacts() *ArtifactsBuilder
-	Apply(ctx *ExContext, artifacts *Artifacts) *Manifest
+	Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, error)
 	Output(manifest *Manifest) map[string]interface{}
 }
 

--- a/playground/recipe_buildernet.go
+++ b/playground/recipe_buildernet.go
@@ -40,9 +40,12 @@ func (b *BuilderNetRecipe) Artifacts() *ArtifactsBuilder {
 	return b.l1Recipe.Artifacts()
 }
 
-func (b *BuilderNetRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
+func (b *BuilderNetRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, error) {
 	// Start with the L1Recipe manifest
-	svcManager := b.l1Recipe.Apply(ctx, artifacts)
+	svcManager, err := b.l1Recipe.Apply(ctx, artifacts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply L1 recipe for BuilderNet: %w", err)
+	}
 
 	// Add builder-hub-postgres service (now includes migrations)
 	svcManager.AddService("builder-hub-postgres", &BuilderHubPostgres{})
@@ -59,7 +62,7 @@ func (b *BuilderNetRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest
 		})
 	}
 
-	return svcManager
+	return svcManager, nil
 }
 
 func (b *BuilderNetRecipe) Output(manifest *Manifest) map[string]interface{} {

--- a/playground/recipe_l1.go
+++ b/playground/recipe_l1.go
@@ -49,7 +49,7 @@ func (l *L1Recipe) Artifacts() *ArtifactsBuilder {
 	return builder
 }
 
-func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
+func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, error) {
 	svcManager := NewManifest(ctx, artifacts.Out)
 
 	svcManager.AddService("el", &RethEL{
@@ -86,7 +86,7 @@ func (l *L1Recipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		BeaconClient:     "beacon",
 		ValidationServer: mevBoostValidationServer,
 	})
-	return svcManager
+	return svcManager, nil
 }
 
 func (l *L1Recipe) Output(manifest *Manifest) map[string]interface{} {

--- a/playground/recipe_opstack.go
+++ b/playground/recipe_opstack.go
@@ -48,7 +48,7 @@ func (o *OpRecipe) Artifacts() *ArtifactsBuilder {
 	return builder
 }
 
-func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
+func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, error) {
 	svcManager := NewManifest(ctx, artifacts.Out)
 	svcManager.AddService("el", &RethEL{})
 	svcManager.AddService("beacon", &LighthouseBeaconNode{
@@ -87,7 +87,7 @@ func (o *OpRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		RollupNode:         "op-node",
 		MaxChannelDuration: o.batcherMaxChannelDuration,
 	})
-	return svcManager
+	return svcManager, nil
 }
 
 func (o *OpRecipe) Output(manifest *Manifest) map[string]interface{} {

--- a/playground/recipe_phylax.go
+++ b/playground/recipe_phylax.go
@@ -1,6 +1,9 @@
 package playground
 
 import (
+	"fmt"
+	"strings"
+
 	flag "github.com/spf13/pflag"
 )
 
@@ -41,6 +44,9 @@ type OpTalosRecipe struct {
 
 	// faucetPrivateKey is the private key of the faucet address
 	faucetPrivateKey string
+
+	// opTalosImageTag is the docker image tag for op-talos
+	opTalosImageTag string
 }
 
 func (o *OpTalosRecipe) Name() string {
@@ -65,6 +71,7 @@ func (o *OpTalosRecipe) Flags() *flag.FlagSet {
 	flags.BoolVar(&o.faucetUi, "faucet-ui", false, "Enable the faucet UI")
 	// Default: $(cast keccak "credible-layer-sandbox-faucet") -> Address: 0xA242C9e875a3135644a171CE7e0d44A14511F897
 	flags.StringVar(&o.faucetPrivateKey, "faucet-private-key", "0x0263f53e0add655d0caa4daaeaf8aa749689beed953a902fc16adf3b944e7fd4", "Private key for faucet")
+	flags.StringVar(&o.opTalosImageTag, "op-talos-image-tag", "", "op-talos docker image specification in 'imagename:tag' format. If provided, both imagename and tag must be non-empty.")
 	return flags
 }
 
@@ -85,6 +92,18 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		if o.assertionDAPrivateKey == "" {
 			panic("assertion-da-private-key is required when external-da is unset, empty, or 'dev'")
 		}
+	}
+
+	parsedImageName := "ghcr.io/phylaxsystems/op-talos/op-rbuilder" // Default image name
+	parsedImageTag := "master"                                      // Default image tag
+
+	if o.opTalosImageTag != "" { // If the flag was provided
+		parts := strings.SplitN(o.opTalosImageTag, ":", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			panic(fmt.Sprintf("Invalid --op-talos-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts.", o.opTalosImageTag))
+		}
+		parsedImageName = parts[0]
+		parsedImageTag = parts[1]
 	}
 
 	svcManager := NewManifest(ctx, artifacts.Out)
@@ -112,6 +131,8 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 			AssertionDA:    externalDaRef,
 			AssexGasLimit:  o.assexGasLimit,
 			OracleContract: o.oracleContract,
+			ImageName:      parsedImageName, // Use parsed/default image name
+			ImageTag:       parsedImageTag,  // Use parsed/default image tag
 		})
 		externalBuilderRef = Connect("op-talos", "authrpc")
 	}

--- a/playground/recipe_phylax.go
+++ b/playground/recipe_phylax.go
@@ -86,7 +86,7 @@ func (o *OpTalosRecipe) Artifacts() *ArtifactsBuilder {
 	return builder
 }
 
-func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
+func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, error) {
 	// Validate required flags
 	if o.externalDA == "" || o.externalDA == "dev" {
 		if o.assertionDAPrivateKey == "" {
@@ -100,7 +100,7 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 	if o.opTalosImageTag != "" { // If the flag was provided
 		parts := strings.SplitN(o.opTalosImageTag, ":", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			panic(fmt.Sprintf("Invalid --op-talos-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts.", o.opTalosImageTag))
+			return nil, fmt.Errorf("Invalid --op-talos-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts.", o.opTalosImageTag)
 		}
 		parsedImageName = parts[0]
 		parsedImageTag = parts[1]
@@ -131,8 +131,8 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 			AssertionDA:    externalDaRef,
 			AssexGasLimit:  o.assexGasLimit,
 			OracleContract: o.oracleContract,
-			ImageName:      parsedImageName, // Use parsed/default image name
-			ImageTag:       parsedImageTag,  // Use parsed/default image tag
+			ImageName:      parsedImageName,
+			ImageTag:       parsedImageTag,
 		})
 		externalBuilderRef = Connect("op-talos", "authrpc")
 	}
@@ -166,7 +166,7 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) *Manifest {
 		RollupNode:         "op-node",
 		MaxChannelDuration: o.batcherMaxChannelDuration,
 	})
-	return svcManager
+	return svcManager, nil
 }
 
 func (o *OpTalosRecipe) Output(manifest *Manifest) map[string]interface{} {


### PR DESCRIPTION
- Adds flag to pcl recipe that allows passing of custom op-talos docker images to the playround in the format of:
```
--op-talos-image-tag docker-image:tag
```
- https://linear.app/phylaxsystems/issue/ENG-629/featplayground-allow-custom-op-talos-images