### PR TITLE
feat: op-talos trusted peers

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Install docker compose
         run: ./scripts/ci-setup-docker-compose.sh
 
+      - name: Log in to GHCR
+        run: echo ${{ secrets.GH_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Build playground utils
         run: ./scripts/ci-build-playground-utils.sh
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Install docker compose
         run: ./scripts/ci-setup-docker-compose.sh
 
-      - name: Log in to GHCR
-        run: echo ${{ secrets.GH_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u odyslam --password-stdin
 
       - name: Build playground utils
         run: ./scripts/ci-build-playground-utils.sh

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,9 +1,8 @@
-name: Checks
+name: E2E tests
 
 on:
   workflow_dispatch:
   pull_request:
-  merge_group:
   push:
     branches: [main]
 
@@ -28,8 +27,12 @@ jobs:
       - name: Install docker compose
         run: ./scripts/ci-setup-docker-compose.sh
 
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u odyslam --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN}}
 
       - name: Build playground utils
         run: ./scripts/ci-build-playground-utils.sh

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,12 +14,8 @@ jobs:
     strategy:
       matrix:
         flags:
-          - "l1"
-          - "l1 --use-native-reth"
-          - "l1 --with-prometheus"
-          - "opstack"
-          - "opstack --external-builder http://host.docker.internal:4444"
-          - "opstack --enable-latest-fork=10"
+          - "pcl --with-caddy op-talos --with-caddy assertion-da"
+          - "pcl --faucet-ui"
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/cl-proxy/cmd/main.go
+++ b/cl-proxy/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	clproxy "github.com/flashbots/builder-playground/cl-proxy"
+	clproxy "github.com/phylaxsystems/builder-playground/cl-proxy"
 	"github.com/spf13/cobra"
 )
 

--- a/mev-boost-relay/cmd/main.go
+++ b/mev-boost-relay/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	mevboostrelay "github.com/flashbots/builder-playground/mev-boost-relay"
+	mevboostrelay "github.com/phylaxsystems/builder-playground/mev-boost-relay"
 	"github.com/spf13/cobra"
 )
 

--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -709,8 +709,8 @@ func (e *EnodeAddr) ID() enode.ID {
 }
 
 // EnodeURL returns the enode URL for the given service and port
-func EnodeURL(enode *EnodeAddr, serviceName string, portName string) string {
-	pub := enode.PrivKey.PublicKey
+func (e *EnodeAddr) EnodeURL(serviceName string, portName string) string {
+	pub := e.PrivKey.PublicKey
 	pubBytes := ecrypto.FromECDSAPub(&pub)     // 65 bytes, uncompressed
 	pubHex := hex.EncodeToString(pubBytes)[2:] // remove the "04" prefix
 	return fmt.Sprintf("enode://%s@%s", pubHex, ConnectRaw(serviceName, portName, "", ""))

--- a/playground/artifacts.go
+++ b/playground/artifacts.go
@@ -708,6 +708,14 @@ func (e *EnodeAddr) ID() enode.ID {
 	return enode.PubkeyToIDV4(&e.PrivKey.PublicKey)
 }
 
+// EnodeURL returns the enode URL for the given service and port
+func EnodeURL(enode *EnodeAddr, serviceName string, portName string) string {
+	pub := enode.PrivKey.PublicKey
+	pubBytes := ecrypto.FromECDSAPub(&pub)     // 65 bytes, uncompressed
+	pubHex := hex.EncodeToString(pubBytes)[2:] // remove the "04" prefix
+	return fmt.Sprintf("enode://%s@%s", pubHex, ConnectRaw(serviceName, portName, "", ""))
+}
+
 func (o *output) GetEnodeAddr() *EnodeAddr {
 	// TODO: This is a bit enshrined here
 	if o.enodeAddrSeq == nil {

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -102,6 +102,7 @@ func (o *OpTalos) Run(service *Service, ctx *ExContext) {
 			"--ae.rpc_da_url", o.AssertionDA,
 			"--ae.rpc_url", "ws://localhost:8546",
 			"--ae.oracle_contract", o.OracleContract,
+			"--ae.rpc_store_db_path", "/data/rpc_store_db",
 		).
 		WithArtifact("/data/jwtsecret", "jwtsecret").
 		WithArtifact("/data/l2-genesis.json", "l2-genesis.json").

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -102,7 +102,7 @@ func (o *OpTalos) Run(service *Service, ctx *ExContext) {
 			"--ae.rpc_da_url", o.AssertionDA,
 			"--ae.rpc_url", "ws://localhost:8546",
 			"--ae.oracle_contract", o.OracleContract,
-			"--ae.rpc_store_db_path", "/data/rpc_store_db",
+			"--ae.db_path", "/data/assertion_executor",
 		).
 		WithArtifact("/data/jwtsecret", "jwtsecret").
 		WithArtifact("/data/l2-genesis.json", "l2-genesis.json").

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -1,7 +1,6 @@
 package playground
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -80,10 +79,7 @@ type OpTalos struct {
 }
 
 func (o *OpTalos) Run(service *Service, ctx *ExContext) {
-	// fixme(odysseas): This doesn't really print the enode, it prints the ID
-	// I am not certain yet how to get the enode
-	enode := fmt.Sprintf("enode://%s@op-geth:30303", o.GethEnode.ID())
-	fmt.Println(enode)
+	enode := EnodeURL(&o.GethEnode, "op-geth", "rpc")
 	service.WithImage(o.ImageName).
 		WithTag(o.ImageTag).
 		WithArgs(

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -1,6 +1,7 @@
 package playground
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -75,13 +76,17 @@ type OpTalos struct {
 	ImageName      string
 	ImageTag       string
 	BlockTag       string
+	GethEnode      EnodeAddr
 }
 
 func (o *OpTalos) Run(service *Service, ctx *ExContext) {
+	enode := fmt.Sprintf("enode://%s@op-geth:30303", o.GethEnode.ID())
+	fmt.Println(enode)
 	service.WithImage(o.ImageName).
 		WithTag(o.ImageTag).
 		WithArgs(
 			"node",
+			"--trusted-peers", enode,
 			"--authrpc.port", `{{Port "authrpc" 8551}}`,
 			"--authrpc.addr", "0.0.0.0",
 			"--authrpc.jwtsecret", "/data/jwtsecret",
@@ -93,7 +98,6 @@ func (o *OpTalos) Run(service *Service, ctx *ExContext) {
 			"--ws.port", `{{Port "ws" 8546}}`,
 			"--chain", "/data/l2-genesis.json",
 			"--datadir", "/data_op_talos",
-			"--disable-discovery",
 			"--color", "never",
 			"--metrics", `0.0.0.0:{{Port "metrics" 9090}}`,
 			"--port", `{{Port "rpc" 30303}}`,

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -79,7 +79,7 @@ type OpTalos struct {
 }
 
 func (o *OpTalos) Run(service *Service, ctx *ExContext) {
-	enode := EnodeURL(&o.GethEnode, "op-geth", "rpc")
+	enode := o.GethEnode.EnodeURL("op-geth", "rpc")
 	service.WithImage(o.ImageName).
 		WithTag(o.ImageTag).
 		WithArgs(

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -80,6 +80,8 @@ type OpTalos struct {
 }
 
 func (o *OpTalos) Run(service *Service, ctx *ExContext) {
+	// fixme(odysseas): This doesn't really print the enode, it prints the ID
+	// I am not certain yet how to get the enode
 	enode := fmt.Sprintf("enode://%s@op-geth:30303", o.GethEnode.ID())
 	fmt.Println(enode)
 	service.WithImage(o.ImageName).

--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -95,18 +95,18 @@ func (o *OpTalos) Run(service *Service, ctx *ExContext) {
 			"--ws.origins", "*",
 			"--ws.port", `{{Port "ws" 8546}}`,
 			"--chain", "/data/l2-genesis.json",
-			"--datadir", "/data_op_talos",
+			"--datadir", "/data_op_talos/reth",
 			"--color", "never",
 			"--metrics", `0.0.0.0:{{Port "metrics" 9090}}`,
 			"--port", `{{Port "rpc" 30303}}`,
 			"--ae.rpc_da_url", o.AssertionDA,
 			"--ae.rpc_url", "ws://localhost:8546",
 			"--ae.oracle_contract", o.OracleContract,
-			"--ae.db_path", "/data/assertion_executor",
+			"--ae.db_path", "/data_op_talos/assertion_executor",
 		).
 		WithArtifact("/data/jwtsecret", "jwtsecret").
 		WithArtifact("/data/l2-genesis.json", "l2-genesis.json").
-		WithVolume("data", "/data_op_reth").
+		WithVolume("data", "/data_op_talos").
 		WithEnv("AE_ASSERTION_GAS_LIMIT", strconv.FormatUint(o.AssexGasLimit, 10)).
 		WithEnv("AE_BLOCK_TAG", o.BlockTag).
 		WithEnv("RUST_LOG", logLevelToTalosVerbosity(ctx.LogLevel))

--- a/playground/recipe_phylax.go
+++ b/playground/recipe_phylax.go
@@ -145,7 +145,7 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, 
 		})
 		externalBuilderRef = Connect("op-talos", "authrpc")
 	} else {
-		fmt.Sprintln("External Builder configured. Please add the following enode to the trusted peers: %s", geth.Enode)
+		fmt.Sprintln("External Builder configured. Please add the following enode to the trusted peers: %s", geth.Enode.EnodeURL("op-geth", "rpc"))
 	}
 
 	externalHttpRef := Connect("op-talos", "http")

--- a/playground/recipe_phylax.go
+++ b/playground/recipe_phylax.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"log"
+
 	flag "github.com/spf13/pflag"
 )
 
@@ -104,7 +106,7 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, 
 	if o.opTalosImageTag != "" { // If the flag was provided
 		parts := strings.SplitN(o.opTalosImageTag, ":", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return nil, fmt.Errorf("Invalid --op-talos-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts.", o.opTalosImageTag)
+			return nil, fmt.Errorf("invalid --op-talos-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts", o.opTalosImageTag)
 		}
 		parsedImageName = parts[0]
 		parsedImageTag = parts[1]
@@ -145,9 +147,13 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, 
 		})
 		externalBuilderRef = Connect("op-talos", "authrpc")
 	} else {
-		fmt.Sprintln("External Builder configured. Please add the following enode to the trusted peers: %s", geth.Enode.EnodeURL("op-geth", "rpc"))
-	}
+		// Extract just the enode ID portion without the template
+		enodeURL := geth.Enode.EnodeURL("op-geth", "rpc")
+		enodeID := strings.Split(enodeURL, "@")[0]
 
+		// Log clear instructions for the user
+		log.Printf("External Builder configured. Sequencer EL enode: %s@<RPC_ENDPOINT>", enodeID)
+	}
 	externalHttpRef := Connect("op-talos", "http")
 
 	if o.faucetUi {
@@ -181,14 +187,6 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, 
 }
 
 func (o *OpTalosRecipe) Output(manifest *Manifest) map[string]interface{} {
-	/*
-		opGeth := manifest.MustGetService("op-geth").component.(*OpGeth)
-		if opGeth.Enode != "" {
-			// Only output if enode was set
-			return map[string]interface{}{
-				"op-geth-enode": opGeth.Enode,
-			}
-		}
-	*/
+	// Just return empty map for now
 	return map[string]interface{}{}
 }


### PR DESCRIPTION
1. Add op-geth as a trusted peer by dynamically generating the enode of op-geth and then pasing it to op-talos
2. Improve metrics scraping by using different jobs to scrape metrics from every service, such that the job_name can be used to dinstuingsh which metrics come from which services
3. Fix persistent indexer database in binded volume