### PR TITLE
feat: expose DA image tag flag

### DIFF
--- a/playground/components_phylax.go
+++ b/playground/components_phylax.go
@@ -5,20 +5,15 @@ import (
 )
 
 type AssertionDA struct {
-	DevMode bool
-	Pk      string
+	Pk        string
+	ImageName string
+	ImageTag  string
 }
 
 func (a *AssertionDA) Run(service *Service, ctx *ExContext) {
-	var name string
-	if a.DevMode {
-		name = "ghcr.io/phylaxsystems/assertion-da/assertion-da-dev"
-	} else {
-		name = "ghcr.io/phylaxsystems/assertion-da/assertion-da"
-	}
 	service.
-		WithImage(name).
-		WithTag("main").
+		WithImage(a.ImageName).
+		WithTag(a.ImageTag).
 		WithArgs("--listen-addr", "0.0.0.0:"+`{{Port "http" 5001}}`, "--private-key", a.Pk).
 		WithAbsoluteVolume("/var/run/docker.sock", "/var/run/docker.sock").
 		WithAbsoluteVolume("/tmp", "/tmp").

--- a/playground/recipe_phylax.go
+++ b/playground/recipe_phylax.go
@@ -32,6 +32,9 @@ type OpTalosRecipe struct {
 	// a new assertion-da service and connects it to the external DA.
 	externalDA string
 
+	// assertionDAImageTag is the docker image tag for assertion-da
+	assertionDAImageTag string
+
 	// assertionDAPrivateKey is the private key of the assertion DA
 	assertionDAPrivateKey string
 
@@ -66,6 +69,7 @@ func (o *OpTalosRecipe) Flags() *flag.FlagSet {
 	flags := flag.NewFlagSet("pcl", flag.ContinueOnError)
 	flags.StringVar(&o.externalBuilder, "external-builder", "", "External builder URL")
 	flags.StringVar(&o.externalDA, "external-da", "", "External DA URL")
+	flags.StringVar(&o.assertionDAImageTag, "assertion-da-image-tag", "", "assertion-da docker image specification in 'imagename:tag' format. If provided, both imagename and tag must be non-empty.")
 	// Default: $(cast keccak "credible-layer-sandbox-assertion-da") -> Address: 0xEc64B5CC78f8f0f2d17Fa2D48DdEFc9abdf68c2B
 	flags.StringVar(&o.assertionDAPrivateKey, "assertion-da-private-key", "0xb14a93020522e378f565ebd6d1032b06af46dc778a1bfea9602a9641547c4673", "Private key for assertion DA (required if external-da is unset, empty, or 'dev')")
 	flags.Var(&nullableUint64Value{&o.enableLatestFork}, "enable-latest-fork", "Enable latest fork isthmus (nil or empty = disabled, otherwise enabled at specified block)")
@@ -93,23 +97,36 @@ func (o *OpTalosRecipe) Artifacts() *ArtifactsBuilder {
 }
 
 func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, error) {
+
+	parsedImageNameAssertionDa := "ghcr.io/phylaxsystems/assertion-da/assertion-da" // Default image name
+	parsedImageTagAssertionDa := "master"                                           // Default image tag
+
 	// Validate required flags
-	if o.externalDA == "" || o.externalDA == "dev" {
+	if o.externalDA == "" {
 		if o.assertionDAPrivateKey == "" {
-			panic("assertion-da-private-key is required when external-da is unset, empty, or 'dev'")
+			panic("assertion-da-private-key is required when external-da is unset or empty")
 		}
 	}
 
-	parsedImageName := "ghcr.io/phylaxsystems/op-talos/op-rbuilder" // Default image name
-	parsedImageTag := "master"                                      // Default image tag
+	if o.assertionDAImageTag != "" { // If the flag was provided
+		parts := strings.SplitN(o.assertionDAImageTag, ":", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid --assertion-da-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts", o.assertionDAImageTag)
+		}
+		parsedImageNameAssertionDa = parts[0]
+		parsedImageTagAssertionDa = parts[1]
+	}
+
+	parsedImageNameOpTalos := "ghcr.io/phylaxsystems/op-talos/op-rbuilder" // Default image name
+	parsedImageTagOpTalos := "master"                                      // Default image tag
 
 	if o.opTalosImageTag != "" { // If the flag was provided
 		parts := strings.SplitN(o.opTalosImageTag, ":", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return nil, fmt.Errorf("invalid --op-talos-image-tag value: '%s'. Must be in 'imagename:tag' format with non-empty imagename and tag parts", o.opTalosImageTag)
 		}
-		parsedImageName = parts[0]
-		parsedImageTag = parts[1]
+		parsedImageNameOpTalos = parts[0]
+		parsedImageTagOpTalos = parts[1]
 	}
 
 	svcManager := NewManifest(ctx, artifacts.Out)
@@ -127,8 +144,9 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, 
 	externalDaRef := o.externalDA
 	if o.externalDA == "" || o.externalDA == "dev" {
 		svcManager.AddService("assertion-da", &AssertionDA{
-			DevMode: o.externalDA == "dev",
-			Pk:      o.assertionDAPrivateKey,
+			Pk:        o.assertionDAPrivateKey,
+			ImageName: parsedImageNameAssertionDa,
+			ImageTag:  parsedImageTagAssertionDa,
 		})
 		externalDaRef = Connect("assertion-da", "http")
 	}
@@ -140,8 +158,8 @@ func (o *OpTalosRecipe) Apply(ctx *ExContext, artifacts *Artifacts) (*Manifest, 
 			AssertionDA:    externalDaRef,
 			AssexGasLimit:  o.assexGasLimit,
 			OracleContract: o.oracleContract,
-			ImageName:      parsedImageName,
-			ImageTag:       parsedImageTag,
+			ImageName:      parsedImageNameOpTalos,
+			ImageTag:       parsedImageTagOpTalos,
 			BlockTag:       o.opTalosBlockTag,
 			GethEnode:      *geth.Enode,
 		})


### PR DESCRIPTION
This change adds AssertionDA image name

It also removes the external URL "dev" hack to run the dev image. Since we are exposing a flag to set the DA image the consumer can set the dev da through this flag. 

